### PR TITLE
Command palette implementation

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { File, Tag } from 'lucide-react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { getAllContentForSearch } from '@/lib/actions/search';
+import { ContentItem } from '@/lib/content/types';
+import { contentConfig } from '@/config/content.config';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const router = useRouter();
+  const [allContent, setAllContent] = useState<ContentItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Load all content when the palette opens
+  useEffect(() => {
+    if (open && allContent.length === 0) {
+      setIsLoading(true);
+      getAllContentForSearch()
+        .then((items) => {
+          setAllContent(items);
+        })
+        .catch((error) => {
+          console.error('Failed to load content:', error);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [open, allContent.length]);
+
+  const handleSelect = useCallback(
+    (contentType: string, slug: string) => {
+      onOpenChange(false);
+      router.push(`/${contentType}/${slug}`);
+    },
+    [onOpenChange, router]
+  );
+
+  // Group content by type
+  const contentByType = allContent.reduce((acc, item) => {
+    if (!acc[item.contentType]) {
+      acc[item.contentType] = [];
+    }
+    acc[item.contentType].push(item);
+    return acc;
+  }, {} as Record<string, ContentItem[]>);
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Search content by title or summary..." />
+      <CommandList>
+        {isLoading ? (
+          <div className="py-6 text-center text-sm text-muted-foreground">
+            Loading content...
+          </div>
+        ) : (
+          <>
+            <CommandEmpty>No results found.</CommandEmpty>
+            
+            {Object.entries(contentByType).map(([type, items]) => {
+              const typeConfig = contentConfig.types[type];
+              if (!typeConfig) return null;
+
+              return (
+                <CommandGroup
+                  key={type}
+                  heading={typeConfig.namePlural}
+                >
+                  {items.map((item) => (
+                    <CommandItem
+                      key={`${item.contentType}-${item.slug}`}
+                      value={`${item.meta.title} ${item.meta.summary || ''}`}
+                      onSelect={() => handleSelect(item.contentType, item.slug)}
+                      className="flex items-start gap-3 py-3"
+                    >
+                      <File className="h-4 w-4 mt-0.5 shrink-0 opacity-50" />
+                      <div className="flex-1 overflow-hidden">
+                        <div className="font-medium truncate">
+                          {item.meta.title}
+                        </div>
+                        {item.meta.summary && (
+                          <div className="text-xs text-muted-foreground line-clamp-1 mt-0.5">
+                            {item.meta.summary}
+                          </div>
+                        )}
+                        {item.meta.tags && item.meta.tags.length > 0 && (
+                          <div className="flex items-center gap-1 mt-1.5 flex-wrap">
+                            {item.meta.tags.slice(0, 3).map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                              >
+                                <Tag className="h-2.5 w-2.5" />
+                                {tag}
+                              </span>
+                            ))}
+                            {item.meta.tags.length > 3 && (
+                              <span className="text-xs text-muted-foreground">
+                                +{item.meta.tags.length - 3}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              );
+            })}
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,10 +10,12 @@ import { directoryConfig } from '@/config/directory.config';
 import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { MobileMenu } from '@/components/MobileMenu';
+import { CommandPalette } from '@/components/CommandPalette';
 
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
   const pathname = usePathname();
 
   // Get content types for navigation
@@ -34,8 +36,7 @@ export function Header() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
-        // TODO: Open command palette when implemented
-        console.log('Open search');
+        setIsCommandPaletteOpen(true);
       }
     };
 
@@ -100,10 +101,7 @@ export function Header() {
                 variant="ghost"
                 size="sm"
                 className="hidden sm:flex items-center gap-2 text-muted-foreground hover:text-foreground"
-                onClick={() => {
-                  // TODO: Open command palette
-                  console.log('Open search');
-                }}
+                onClick={() => setIsCommandPaletteOpen(true)}
               >
                 <Search className="h-4 w-4" />
                 <span className="text-caption hidden lg:inline">Search</span>
@@ -134,8 +132,15 @@ export function Header() {
       <MobileMenu
         isOpen={isMobileMenuOpen}
         onClose={() => setIsMobileMenuOpen(false)}
+        onOpenCommandPalette={() => setIsCommandPaletteOpen(true)}
         contentTypes={contentTypes}
         currentPath={pathname}
+      />
+
+      {/* Command Palette */}
+      <CommandPalette
+        open={isCommandPaletteOpen}
+        onOpenChange={setIsCommandPaletteOpen}
       />
 
       {/* Spacer for fixed header */}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -19,6 +19,7 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 interface MobileMenuProps {
   isOpen: boolean;
   onClose: () => void;
+  onOpenCommandPalette: () => void;
   contentTypes: ContentTypeConfig[];
   currentPath: string;
 }
@@ -26,6 +27,7 @@ interface MobileMenuProps {
 export function MobileMenu({
   isOpen,
   onClose,
+  onOpenCommandPalette,
   contentTypes,
   currentPath,
 }: MobileMenuProps) {
@@ -62,8 +64,7 @@ export function MobileMenu({
               className="w-full justify-start gap-3 h-12 text-muted-foreground"
               onClick={() => {
                 onClose();
-                // TODO: Open command palette
-                console.log('Open search');
+                onOpenCommandPalette();
               }}
             >
               <Search className="h-4 w-4" />

--- a/src/lib/actions/search.ts
+++ b/src/lib/actions/search.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import { getContent } from '@/lib/content/loader';
+import { ContentItem } from '@/lib/content/types';
+
+/**
+ * Server action to fetch all content for search
+ */
+export async function getAllContentForSearch(): Promise<ContentItem[]> {
+  try {
+    const result = await getContent({ pageSize: 1000 });
+    return result.items;
+  } catch (error) {
+    console.error('Failed to load content for search:', error);
+    return [];
+  }
+}

--- a/src/lib/actions/search.ts
+++ b/src/lib/actions/search.ts
@@ -1,15 +1,14 @@
 'use server';
 
-import { getContent } from '@/lib/content/loader';
-import { ContentItem } from '@/lib/content/types';
+import { getAllContentForSearch as getSearchContent } from '@/lib/content/loader';
 
 /**
- * Server action to fetch all content for search
+ * Server action to fetch all content for search (without full MDX content)
+ * This returns all content items with only metadata, excluding the large content field
  */
-export async function getAllContentForSearch(): Promise<ContentItem[]> {
+export async function getAllContentForSearch() {
   try {
-    const result = await getContent({ pageSize: 1000 });
-    return result.items;
+    return await getSearchContent();
   } catch (error) {
     console.error('Failed to load content for search:', error);
     return [];

--- a/src/lib/content/loader.ts
+++ b/src/lib/content/loader.ts
@@ -233,3 +233,14 @@ export function getContentTypes(): string[] {
 export function isValidContentType(contentType: string): boolean {
   return contentType in contentConfig.types;
 }
+
+/**
+ * Get all content for search (without the large MDX content field)
+ */
+export async function getAllContentForSearch(): Promise<
+  Array<Omit<ContentItem, 'content'>>
+> {
+  const items = loadAllContent();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return items.map(({ content, ...rest }) => rest);
+}


### PR DESCRIPTION
Implement the Search Command Palette to enable content search via keyboard shortcut (⌘K/Ctrl+K) and UI buttons, resolving critical issue PERS-94.

---
Linear Issue: [PERS-94](https://linear.app/provenant/issue/PERS-94/critical-implement-search-command-palette)

<a href="https://cursor.com/background-agent?bcId=bc-6e21cbd6-18b6-4cf7-a237-b12815495105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e21cbd6-18b6-4cf7-a237-b12815495105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a global search command palette and wires it into desktop and mobile navigation.
> 
> - Adds `CommandPalette` (client) with grouped results by content type, showing titles/summaries/tags, and navigates on select
> - Introduces server action `lib/actions/search.ts` (`getAllContentForSearch`) to fetch content via `getContent`
> - Integrates palette in `Header` with Cmd/Ctrl+K shortcut and search button; updates `MobileMenu` to open the palette from its search entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb4883bcf786a96698f3c4ccff4022997fa17b96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->